### PR TITLE
Update version check in RadonProvider.ts

### DIFF
--- a/src/RadonProvider.ts
+++ b/src/RadonProvider.ts
@@ -75,7 +75,7 @@ export default class RadonProvider implements CodeLensProvider {
     private retrieveData(document: TextDocument) {
         radon.getVersion().then(version => {
             const [major, minor] = version;
-            if (major < 5 || minor < 1) {
+            if (major < 5 || (major == 5 && minor < 1)) {
                 throw new UnsupportedVersionException("You need at least python radon version 5.1 installed. Try pip install \"radon>=5.1\".");
             }
             return Promise.all([


### PR DESCRIPTION
Fix for Issue #5 

Fix version check to allow major versions higher than 5 and with minor versions lower than 1 (like 6.0.1)