### PR TITLE
fixed a radon version checking bug

### DIFF
--- a/src/RadonProvider.ts
+++ b/src/RadonProvider.ts
@@ -75,7 +75,7 @@ export default class RadonProvider implements CodeLensProvider {
     private retrieveData(document: TextDocument) {
         radon.getVersion().then(version => {
             const [major, minor] = version;
-            if (major < 5 || minor < 1) {
+            if (major < 5 || (major == 5 && minor < 1)) {
                 throw new UnsupportedVersionException("You need at least python radon version 5.1 installed. Try pip install \"radon>=5.1\".");
             }
             return Promise.all([


### PR DESCRIPTION
Description:

This PR addresses an issue with the version checking logic for Python Radon. Previously, the logic could incorrectly flag versions like 6.0 as unsupported due to an incorrect minor version check. The updated logic ensures that only versions less than 5.1 are flagged as unsupported.

Changes:

Updated the version checking logic to correctly identify versions less than 5.1.